### PR TITLE
Formatting support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
           - ubuntu-latest
 
         rzk-version:
-          - v0.6.6
+          - v0.7.1
           - latest
 
         files:
@@ -30,6 +30,14 @@ jobs:
         with:
           rzk-version: ${{ matrix.rzk-version }}
           files: ${{ matrix.files }}
+      
+      - name: Check formatting only
+        uses: ./
+        with:
+          rzk-version: ${{ matrix.rzk-version }}
+          files: ${{ matrix.files }}
+          typecheck: false
+          check-formatting: true
 
       - name: Check action's output
         shell: bash

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ The following example runs `rzk typecheck` on all literate Rzk Markdown files in
 
 ## Inputs
 
-| Name          | Required | Description                                          | Type    | Default                       |
-| ------------- | :------: | ---------------------------------------------------- | ------- | ----------------------------- |
-| `rzk-version` |    No    | `rzk` version to use, ex. `latest` or `v0.5.3`       | string  | `latest`                      |
-| `files`       |    No    | Files to process, ex. `lib/**/*.rzk src/**/*.rzk.md` | string  | Rely on local `rzk.yaml` file |
-| `system-rzk`  |    No    | Use `rzk` executable provided by the system          | boolean | `false`                       |
-| `typecheck`   |    No    | Typecheck the input files                            | boolean | `true`                        |
+| Name               | Required | Description                                          | Type    | Default                       |
+| ------------------ | :------: | ---------------------------------------------------- | ------- | ----------------------------- |
+| `rzk-version`      |    No    | `rzk` version to use, ex. `latest` or `v0.5.3`       | string  | `latest`                      |
+| `files`            |    No    | Files to process, ex. `lib/**/*.rzk src/**/*.rzk.md` | string  | Rely on local `rzk.yaml` file |
+| `system-rzk`       |    No    | Use `rzk` executable provided by the system          | boolean | `false`                       |
+| `typecheck`        |    No    | Typecheck the input files                            | boolean | `true`                        |
+| `check-formatting` |    No    | Check that the input files are well-formatted        | boolean | `false`                       |
 
 It only makes sense to turn off typechecking when checking the formatting.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The following example runs `rzk typecheck` on all literate Rzk Markdown files in
 | `rzk-version` |    No    | `rzk` version to use, ex. `latest` or `v0.5.3`       | string  | `latest`                      |
 | `files`       |    No    | Files to process, ex. `lib/**/*.rzk src/**/*.rzk.md` | string  | Rely on local `rzk.yaml` file |
 | `system-rzk`  |    No    | Use `rzk` executable provided by the system          | boolean | `false`                       |
+| `typecheck`   |    No    | Typecheck the input files                            | boolean | `true`                        |
+
+It only makes sense to turn off typechecking when checking the formatting.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: "Enable typechecking the files (on by default)"
     required: false
     default: true
+  check-formatting:
+    description: "Enable checking the formatting (off by default)"
+    required: false
+    default: false
 
 outputs:
   rzk-version:
@@ -45,8 +49,14 @@ runs:
       run: |
         echo "rzk-version=$(rzk version)" >> $GITHUB_OUTPUT
 
-    - name: 🔨 Check Rzk files
+    - name: 🔨 Check Rzk files definitions
       shell: bash
       if: ${{ inputs.typecheck == 'true' }}
       run: |
         rzk typecheck ${{ inputs.files }}
+
+    - name: 🔬 Check Rzk files formatting
+      shell: bash
+      if: ${{ inputs.check-formatting == 'true' }}
+      run: |
+        rzk format --check ${{ inputs.files }}

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: "Files to check (rely on rzk.yaml by default)"
     required: false
     default: ""
+  typecheck:
+    description: "Enable typechecking the files (on by default)"
+    required: false
+    default: true
 
 outputs:
   rzk-version:
@@ -43,5 +47,6 @@ runs:
 
     - name: 🔨 Check Rzk files
       shell: bash
+      if: ${{ inputs.typecheck == 'true' }}
       run: |
         rzk typecheck ${{ inputs.files }}

--- a/example/1-example.rzk.md
+++ b/example/1-example.rzk.md
@@ -8,7 +8,7 @@ Here's a sample definition to typecheck:
 
 ```rzk
 #define modus-ponens
-  (A B : U)
-  : (A → B) → A → B
+  ( A B : U)
+  : ( A → B) → A → B
   := \ f x → f x
 ```


### PR DESCRIPTION
Adds an option to check formatting of the input files.

I'm having second thoughts about this. Part of me wants to have this be just a `setup-rzk` action (just like actions/setup-node, Python, Dart, Haskell, ...), with the `rzk typecheck` (or `rzk format --check`) command being manually run by the workflow that uses this action. This allows for larger flexibility (even `rzk --write` if it makes sense for some usecase).

On the other hand, I can see the "check-formatting" option growing into "lint", with annotations on GitHub Pull Requests changed files